### PR TITLE
Fixed Gruntfile and grunt dependencies to accomodate jasmine

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -57,7 +57,7 @@ module.exports = function (grunt) {
                 template: require('grunt-template-jasmine-requirejs'),
                 templateOptions: {
                     requireConfig: {
-                        baseUrl: '.app/',
+                        baseUrl: './app/',
                         mainConfigFile: './app/main.js'
                     }
                 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "Gruntfile.js",
   "dependencies": {},
   "devDependencies": {
-    "grunt": "~0.4.0rc2",
+    "grunt": "~0.4.1",
     "grunt-contrib-watch": "~0.1.4",
     "grunt-contrib-jshint": "https://github.com/gruntjs/grunt-contrib-jshint/archive/7fd70e86c5a8d489095fa81589d95dccb8eb3a46.tar.gz",
     "grunt-contrib-uglify": "~0.1.0",


### PR DESCRIPTION
Fixed for issue https://github.com/jsoverson/grunt-template-jasmine-requirejs/issues/15 on grunt-template-jasmine-requirejs

You had an old rc version of grunt installed, which wasn't passing the src files around as needed. The requirejs config needed to be fixed as well, but you weren't even getting there.

Works now (I didn't check in the node_modules directory so you will still need to npm install, I didn't want a big diff.)
